### PR TITLE
add(docker): Base environment in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/linuxserver/code-server:latest
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV PATH "$PATH:/config/.local/bin"
+
+COPY provision/ /tmp/provision/
+RUN set -x ; for x in /tmp/provision/*.bash ; do bash "$x"; done

--- a/provision/00-apt.bash
+++ b/provision/00-apt.bash
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+apt-get update -y
+apt-get upgrade -y


### PR DESCRIPTION
Configure the base environment in docker based on the PoC project.

The intentions is for the `provision/` directory to contain an ordered set of scripts that will be run in the image to install the tooling. 