### PR TITLE
build(deploy): Enable deploying to GitHub Container Registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,9 +25,9 @@ jobs:
           docker build . \
             --file Dockerfile \
             --tag ${{ steps.vars.outputs.docker_name }}:${{ steps.vars.outputs.docker_tag }} \
-      # - name: Push to GitHub Packages
-      #   if: github.ref == 'refs/heads/main'
-      #   run: |
-      #     echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
-      #     docker tag ${{ steps.vars.outputs.docker_name }}:${{ steps.vars.outputs.docker_tag }} ${{ steps.vars.outputs.docker_name }}:latest
-      #     docker push ${{ steps.vars.outputs.docker_name }}
+      - name: Push to GitHub Packages
+        if: github.ref == 'refs/heads/main'
+        run: |
+          echo ${{ secrets.GHCR_PAT  }} | docker login ghcr.io --username ${{ github.actor }} --password-stdin
+          docker tag ${{ steps.vars.outputs.docker_name }}:${{ steps.vars.outputs.docker_tag }} ${{ steps.vars.outputs.docker_name }}:latest
+          docker push ${{ steps.vars.outputs.docker_name }}


### PR DESCRIPTION
Enable deploying to GitHub Container Registry.

This takes over the responsibility of deploying to the image from the proof of concept repository. 