### PR TITLE
docs(readme): Stub out the project readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,3 +8,5 @@ COPY settings/ /tmp/settings/
 
 COPY provision/ /tmp/provision/
 RUN set -x ; for x in /tmp/provision/*.bash ; do bash "$x"; done
+
+LABEL org.opencontainers.image.source https://github.com/jrbeverly/codespace

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# codespace
-Prebuilt, development environment in the browser – powered by VS Code
+# Codespace
+
+Prebuilt, development environment in the browser – powered by VS Code.
+
+This image acts as a catch-all image for doing full-stack development in a polyglot type environment. The running container makes use of the host docker service to allow for docker builds.


### PR DESCRIPTION
Stub out the project README is a simple form.

This is intended to just act as a temporary description of the intentions. Later documentation can be added about ideas or intentions around environments as code.