### PR TITLE
fix(bazel): Buildozer using wrong GitHub releases URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN set -x ; \
     TMPDIR=$(mktemp -d 'install-XXXXXXXX') ; \
     cd ${TMPDIR} ; \
     for x in /tmp/provision/*.bash ; do bash "$x"; done ; \
-    rm -rf ${TMPDIR}
+    rm -rf ${TMPDIR} /tmp/settings/
 
 LABEL org.opencontainers.image.source https://github.com/jrbeverly/codespace

--- a/provision/13-bazel.bash
+++ b/provision/13-bazel.bash
@@ -13,7 +13,7 @@ bazel --version
 latest=$(github_get_latest_release bazelbuild/buildtools)
 echo "bazelbuild/buildtools latest release: ${latest}"
 
-curl -sSL https://github.com/bazelbuild/buildtools/releases/download/${latest}/buildifier > /usr/bin/buildifier
-curl -sSL https://github.com/bazelbuild/buildtools/releases/download/${latest}/buildozer > /usr/bin/buildozer
+curl -sSL https://github.com/bazelbuild/buildtools/releases/download/${latest}/buildifier-linux-amd64 > /usr/bin/buildifier
+curl -sSL https://github.com/bazelbuild/buildtools/releases/download/${latest}/buildozer-linux-amd64 > /usr/bin/buildozer
 chmod +x /usr/bin/buildifier
 chmod +x /usr/bin/buildozer


### PR DESCRIPTION
GitHub releases URL for buildozer was incorrect, resulting in bad binary on installed image